### PR TITLE
MODCLUSTER-696 Update Content Security Policies

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,5 +1,5 @@
 <!-- https://infosec.mozilla.org/guidelines/web_security#content-security-policy -->
-<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self' 'sha256-CwE3Bg0VYQOIdNAkbB/Btdkhul49qZuwgNCMPgNY5zw=' https://fonts.googleapis.com; font-src 'self'; form-action 'none'; frame-ancestors 'none'; base-uri 'none';">
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self' 'sha256-CwE3Bg0VYQOIdNAkbB/Btdkhul49qZuwgNCMPgNY5zw=' 'sha256-anQSeQoEnQnBulZOQkDOFf+e6xBIGmqh7M8YFT992co=' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; form-action 'none'; base-uri 'none';">
 
 <meta charset="utf-8">
 <title>{% if page.title %}{{ page.title }} &#8211; {% endif %}{{ site.title }}</title>


### PR DESCRIPTION
* Content Security Policies delivered via a <meta> element may not contain the frame-ancestors directive.
* Allow fonts from gstatic
* add hash for inlined scripts.min.js:1 Refused to apply inline style because it violates the following Content Security Policy